### PR TITLE
Add changelog overwrite capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ jobs:
 | `branch`             | Destination branch to push changes                                                                                                                         | `master`    |
 | `prerelease`         | Set as prerelease {alpha,beta,rc} choose type of prerelease                                                                                                | -           |
 | `extra_requirements` | Custom requirements, if your project uses a custom rule or plugins, you can specify them separated by a space. E.g: `'commitizen-emoji conventional-JIRA'` | -           |
+| `force_changelog`         | Overwrite changelog file, usefull when using multible tag branch (main, dev)                                                                                                | -           |
+
 
 <!--           | `changelog`                                                                                                  | Create changelog when bumping the version | true | -->
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Create changelog when bumping the version'
     default: "true"
     required: false
+  force_changelog:
+    description: 'Overwrite changelog when bumping the version'
+    default: "false"
+    required: false
   github_token:
     description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,10 @@
 if [ $INPUT_DRY_RUN ]; then INPUT_DRY_RUN='--dry-run'; else INPUT_DRY_RUN=''; fi
 if [ $INPUT_CHANGELOG ]; then INPUT_CHANGELOG='--changelog'; else INPUT_CHANGELOG=''; fi
 if [ $INPUT_PRERELEASE ]; then INPUT_PRERELEASE="--prerelease $INPUT_PRERELEASE"; else INPUT_PRERELEASE=''; fi
+INPUT_FORCE_CHANGELOG=${INPUT_FORCE_CHANGELOG:false}
 INPUT_BRANCH=${INPUT_BRANCH:-master}
 INPUT_EXTRA_REQUIREMENTS=${INPUT_EXTRA_REQUIREMENTS:-''}
 REPOSITORY=${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}
-# : "${INPUT_CHANGELOG:=true}" ignroed for now, let's check that it works
 
 set -e
 
@@ -27,6 +27,11 @@ cz version
 echo "Configuring git user and email..."
 git config --local user.email "action@github.com"
 git config --local user.name "GitHub Action"
+
+[ $INPUT_FORCE_CHANGELOG ] && {
+    echo "Remove old changelog"
+    rm CHANGELOG.md
+};
 
 
 echo "Running cz: $INPUT_DRY_RUN $INPUT_CHANGELOG $INPUT_PRERELEASE"


### PR DESCRIPTION
When you work a lot with branch, sometime merge don't merge well changelog file, so it's preferable to rewrite it than use it to start .
Created an option to delete changelog before create new one.
