### PR TITLE
Enable customization of git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,17 @@ jobs:
 
 ## Variables
 
-| Name                           | Description                                                                                                                                                              | Default     |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| `github_token`                 | Token for the repo. Can be passed in using `${{ secrets.GITHUB_TOKEN }}` **required**                                                                                    | -           |
-| `dry_run`                      | Run without creating commit, output to stdout                                                                                                                            | false       |
-| `repository`                   | Repository name to push. Default or empty value represents current github repository                                                                                     | current one |
-| `branch`                       | Destination branch to push changes                                                                                                                                       | `master`    |
-| `prerelease`                   | Set as prerelease {alpha,beta,rc} choose type of prerelease                                                                                                              | -           |
-| `extra_requirements`           | Custom requirements, if your project uses a custom rule or plugins, you can specify them separated by a space. E.g: `'commitizen-emoji conventional-JIRA'`               | -           |
-| `changelog_increment_filename` | Filename to store the incremented generated changelog. This is different to changelog as it only contains the changes for the just generated version. Example: `body.md` | -           |
+| Name                           | Description                                                                                                                                                              | Default                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `github_token`                 | Token for the repo. Can be passed in using `${{ secrets.GITHUB_TOKEN }}` **required**                                                                                    | -                                              |
+| `dry_run`                      | Run without creating commit, output to stdout                                                                                                                            | false                                          |
+| `repository`                   | Repository name to push. Default or empty value represents current github repository                                                                                     | current one                                    |
+| `branch`                       | Destination branch to push changes                                                                                                                                       | `master`                                       |
+| `prerelease`                   | Set as prerelease {alpha,beta,rc} choose type of prerelease                                                                                                              | -                                              |
+| `extra_requirements`           | Custom requirements, if your project uses a custom rule or plugins, you can specify them separated by a space. E.g: `'commitizen-emoji conventional-JIRA'`               | -                                              |
+| `changelog_increment_filename` | Filename to store the incremented generated changelog. This is different to changelog as it only contains the changes for the just generated version. Example: `body.md` | -                                              |
+| `git_name`                     | Name used to configure git (for git operations)                                                                                                                          | `github-actions[bot]`                          |
+| `git_email`                    | Email address used to configure git (for git operations)                                                                                                                 | `github-actions[bot]@users.noreply.github.com` |
 
 <!--           | `changelog`                                                                                                  | Create changelog when bumping the version | true | -->
 

--- a/action.yml
+++ b/action.yml
@@ -35,3 +35,11 @@ inputs:
   changelog_increment_filename:
     description: 'Filename to store the incremented generated changelog. This is different to changelog as it only contains the changes for the just generated version'
     required: false
+  git_name:
+    description: 'Name used to configure git (for git operations)'
+    required: false
+    default: 'github-actions[bot]'
+  git_email:
+    description: 'Email address used to configure git (for git operations)'
+    required: false
+    default: '41898282+github-actions[bot]@users.noreply.github.com'

--- a/action.yml
+++ b/action.yml
@@ -42,4 +42,4 @@ inputs:
   git_email:
     description: 'Email address used to configure git (for git operations)'
     required: false
-    default: '41898282+github-actions[bot]@users.noreply.github.com'
+    default: 'github-actions[bot]@users.noreply.github.com'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,8 +25,10 @@ cz version
 
 
 echo "Configuring git user and email..."
-git config --local user.email "action@github.com"
-git config --local user.name "GitHub Action"
+git config --local user.name "$INPUT_GIT_NAME"
+git config --local user.email "$INPUT_GIT_EMAIL"
+echo "Git name: $(git config --get user.name)"
+echo "Git email: $(git config --get user.email)"
 
 
 echo "Running cz: $INPUT_DRY_RUN $INPUT_CHANGELOG $INPUT_PRERELEASE"


### PR DESCRIPTION
Fixes #10 

This PR introduces two new inputs that are used on the `git config` command, in order to enable git config to be customizable.

- `git_name` - Defaults to `github-actions[bot]`
- `git_email` - Defaults to `github-actions[bot]@users.noreply.github.com`

The default values for the [GitHub Actions app](https://github.com/apps/github-actions).

Also, added two statements to output the configured name and email. Bear in mind those will show masked (`***`) in the workflow logs if the values come from secrets.