### PR TITLE
Add version output and document REVISION env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ jobs:
 
 <!--           | `changelog`                                                                                                  | Create changelog when bumping the version | true | -->
 
+## Outputs
+
+| Name      | Description          |
+| --------- | -------------------- |
+| `version` | The new version      |
+
+Additionally, the new version is also availble as an environment variable under `REVISION`.
+
 ## Troubleshooting
 
 ### Other actions are not triggered when the tag is pushed

--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ jobs:
         with:
           fetch-depth: 0
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Create bump and changelog
+      - id: cz
+        name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print Version
+        run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
 ```
 
 ## Variables

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ runs:
 branding:
   icon: 'git-commit'
   color: 'purple'
+outputs:
+  version:
+    description: 'New version'
 inputs:
   dry_run:
     description: 'Run without creating commit, output to stdout'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,8 @@ fi
 export REV=`cz version --project`
 echo "REVISION=$REV" >> $GITHUB_ENV
 
+echo "::set-output name=version::$REV"
+
 echo "Pushing to branch..."
 remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
 git pull ${remote_repo} ${INPUT_BRANCH}


### PR DESCRIPTION
Fixes #12.

This PR introduces an action output named `version` that has the newly bumped version (equal to `env.REVISION`). Additionally, added both the new output and the `env.REVISION` variable to the `README.md` for increased visibility.