### PR TITLE
Install `libffi-dev` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN set -eux; \
         gpg \
         alpine-sdk \
         bash \
+        libffi-dev \
     ;
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This is required to install [`cffi`](https://pypi.org/project/cffi/), which is a transitive dependency of https://github.com/meltano/commitizen-version-bump

Using `commitizen-action@v0.16.2`: https://github.com/meltano/meltano/actions/runs/4127803197/jobs/7131454934

Using my fork: https://github.com/meltano/meltano/actions/runs/4128122174/jobs/7132196405