### PR TITLE
fix: remove use_ssh flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN set -eux; \
         gpg \
         alpine-sdk \
         bash \
-        openssh \
         libffi-dev \
     ;
 COPY entrypoint.sh /entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -37,10 +37,6 @@ inputs:
   github_token:
     description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
     required: false
-  use_ssh:
-    description: 'Set to true if ssh-key has been configured for the actions/checkout'
-    required: false
-    default: "false"
   repository:
     description: 'Repository name to push. Default or empty value represents current github repository (${GITHUB_REPOSITORY})'
     default: ''

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,8 @@ set -e
 gpg --version
 git --version
 
-if [[ -z $INPUT_GITHUB_TOKEN && $INPUT_USE_SSH != "true" ]]; then
-  echo 'Missing input "github_token: ${{ secrets.GITHUB_TOKEN }}" or "use_ssh", choose one.' >&2
+if [[ -z $INPUT_GITHUB_TOKEN && $INPUT_PUSH == "true" ]]; then
+  echo 'Missing input "github_token: ${{ secrets.GITHUB_TOKEN }}" which is required to push.' >&2
   exit 1
 fi
 
@@ -92,10 +92,6 @@ if [[ $INPUT_PUSH == 'true' ]]; then
   if [[ $INPUT_MERGE != 'true' && $GITHUB_EVENT_NAME == 'pull_request' ]]; then
     echo "Refusing to push on pull_request event since that would merge the pull request." >&2
     echo "You probably want to run on push to your default branch instead." >&2
-  elif [[ $INPUT_USE_SSH == "true" ]]; then
-    echo "Pushing to branch using SSH..."
-    REMOTE_REPO="git@github.com:${INPUT_REPOSITORY}.git"
-    git push "$REMOTE_REPO" "HEAD:${INPUT_BRANCH}" --tags
   else
     echo "Pushing to branch..."
     REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${INPUT_REPOSITORY}.git"


### PR DESCRIPTION
BREAKING CHANGE: Remove `use_ssh`. Documentation is in place to deploy using SSH keys