### PR TITLE
fix: install git-lfs into the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM python:3.8-alpine
 RUN set -eux; \
     apk add --no-cache \
         git \
+        git-lfs \
         gpg \
         alpine-sdk \
         bash \
         libffi-dev \
-    ;
+    ; \
+    git lfs install;
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
For users who have repos that use Git LFS, this includes LFS in the base Dockerfile. Solves this issue: https://github.com/commitizen-tools/commitizen-action/issues/7