### PR TITLE
feat: add local version and devrelease as inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,13 @@ inputs:
   prerelease:
     description: 'Set as prerelease version'
     required: false
+  devrelease:
+    description: 'Non-negative integer for dev. release'
+    required: false
+  local_version:
+    description: 'Bump only the local version portion'
+    required: false
+    default: "false"
   changelog:
     description: 'Create changelog when bumping the version'
     default: "true"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 if [[ $INPUT_DEVRELEASE ]]; then
   CZ_CMD+=('--devrelease' "$INPUT_DEVRELEASE")
 fi
-if [[ $INPUT_LOCAL_VERSION ]]; then
+if [[ $INPUT_LOCAL_VERSION == 'true' ]]; then
   CZ_CMD+=('--local_version')
 fi
 if [[ $INPUT_COMMIT == 'false' ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,12 @@ fi
 if [[ $INPUT_PRERELEASE ]]; then
   CZ_CMD+=('--prerelease' "$INPUT_PRERELEASE")
 fi
+if [[ $INPUT_DEVRELEASE ]]; then
+  CZ_CMD+=('--devrelease' "$INPUT_DEVRELEASE")
+fi
+if [[ $INPUT_LOCAL_VERSION ]]; then
+  CZ_CMD+=('--local_version')
+fi
 if [[ $INPUT_COMMIT == 'false' ]]; then
   CZ_CMD+=('--files-only')
 fi


### PR DESCRIPTION
This is a PR to add `devrelease` and `local_version` to the github action since its already supported by [commitizen here](https://commitizen-tools.github.io/commitizen/bump/#-local-version).