### PR TITLE
feat: add no_verify variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jobs:
 | `check_consistency`            | Check consistency among versions defined in commitizen configuration and version_files                                                                                                                                            | `false`                                                         |
 | `gpg_sign`                     | If true, use GPG to sign commits and tags (for git operations). Requires separate setup of GPG key and passphrase in GitHub Actions (e.g. with the action `crazy-max/ghaction-import-gpg`)                                        | `false`                                                         |
 | `debug`                        | Prints debug output to GitHub Actions stdout                                                                                                                                                                                      | `false`                                                         |
+| `no_verify`                    | If true, bypasses the pre-commit and commit-msg hooks                                                                                                                                                                             | false                                                           |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,10 @@ inputs:
     required: false
     default: "false"
   debug:
-    description: "If true, prints debug output to GitHub Actions stdout."
+    description: 'If true, prints debug output to GitHub Actions stdout.'
     required: false
-    default: "false"
+    default: 'false'
+  no_verify:
+    description: 'If true, bypasses the pre-commit and commit-msg hooks'
+    required: false
+    default: 'false'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,9 @@ if [[ $INPUT_CHANGELOG_INCREMENT_FILENAME ]]; then
   CZ_CMD+=('--changelog-to-stdout')
   echo "${CZ_CMD[@]}" ">$INPUT_CHANGELOG_INCREMENT_FILENAME"
   "${CZ_CMD[@]}" >"$INPUT_CHANGELOG_INCREMENT_FILENAME"
+  if [[ $INPUT_NO_VERIFY == 'true' ]]; then
+    CZ_CMD+=('--no-verify')
+  fi
 else
   echo "${CZ_CMD[@]}"
   "${CZ_CMD[@]}"


### PR DESCRIPTION
When paired with pre-commit, when using the action with `changelog_increment_filename: body.md`, I get the output of pre-commit in my body.md file

Adding no_verify will prevent pre-commit from running on a commit