### PR TITLE
feat: Add PREVIOUS_REVISION to environment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,7 @@ echo "${PIP_CMD[@]}"
 echo "Commitizen version: $(cz version)"
 
 PREV_REV="$(cz version --project)"
+echo "PREVIOUS_REVISION=${PREV_REV}" >>"$GITHUB_ENV"
 
 CZ_CMD=('cz')
 if [[ $INPUT_DEBUG == 'true' ]]; then


### PR DESCRIPTION
This adds the `PREVIOUS_REVISION` environment variable, allowing subsequent workflow steps to detect if the revision was changed by commitizen. 

<details><summary><b>Example workflow</b></summary>
<p>

```yaml
name: Bump version

on:
  push:
    branches:
      - main

jobs:
  bump-version:
    if: "!startsWith(github.event.head_commit.message, 'bump:')"
    runs-on: ubuntu-latest
    environment: release
    steps:
      - name: Check out
        uses: actions/checkout@v3
        with:
          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
          fetch-depth: 0

      - name: Import GPG key
        uses: crazy-max/ghaction-import-gpg@v6
        with:
          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
          passphrase: ${{ secrets.GPG_PASSPHRASE }}

      - name: Create bump and changelog
        uses: commitizen-tools/commitizen-action@master
        with:
          dry_run: true
          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
          changelog_increment_filename: body.md

      - name: Verify commit signature
        if: env.REVISION != env.PREVIOUS_REVISION
        run: git verify-commit HEAD

      - name: Create GitHub release
        if: env.REVISION != env.PREVIOUS_REVISION
        uses: ncipollo/release-action@v1
        with:
          tag: v${{ env.REVISION }}
          bodyFile: "body.md"
          skipIfReleaseExists: true
```

</p>
</details> 