### PR TITLE
ci: use github token by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: "${{ secrets.GITHUB_TOKEN }}"
       - id: cz
         name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
 ```
@@ -66,7 +63,7 @@ jobs:
 
 | Name                           | Description                                                                                                                                                                                                                       | Default                                                         |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `github_token`                 | Token for the repo. Can be passed in using `${{ secrets.GITHUB_TOKEN }}`. Required if `push: true`                                                                                                                                | -                                                               |
+| `github_token`                 | Token for the repo. Can be passed in using `${{ secrets.GITHUB_TOKEN }}` if your want to use a custom PAT                                                                                                                         | `${{ github.token }}`                                           |
 | `dry_run`                      | Run without creating commit, output to stdout                                                                                                                                                                                     | false                                                           |
 | `repository`                   | Repository name to push. Default or empty value represents current github repository                                                                                                                                              | current one                                                     |
 | `branch`                       | Destination branch to push changes                                                                                                                                                                                                | Same as the one executing the action by default                 |

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,7 @@ inputs:
   github_token:
     description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
     required: false
+    default: ${{ github.token }}
   repository:
     description: 'Repository name to push. Default or empty value represents current github repository (${GITHUB_REPOSITORY})'
     default: ''


### PR DESCRIPTION
Set `${{ github.token }}` as the default value for `github_token` input.
This is the common practice, examples:

* https://github.com/actions/checkout/blob/main/action.yml#L24
* https://github.com/astral-sh/setup-uv/pull/61
