### PR TITLE
ci: publish major and minor tags

### DIFF
--- a/.github/workflows/bumpversion.yaml
+++ b/.github/workflows/bumpversion.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          github_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           changelog_increment_filename: body.md
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -25,4 +25,4 @@ jobs:
           body_path: "body.md"
           tag_name: "${{ env.REVISION }}"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"

--- a/.github/workflows/update_semver.yml
+++ b/.github/workflows/update_semver.yml
@@ -1,0 +1,19 @@
+name: Update Major Minor Tags
+
+on:
+  push:
+    branches-ignore:
+      - "**"
+    tags:
+      - "*.*.*"
+  workflow_dispatch:
+
+jobs:
+  update_major_minor_tags:
+    name: Make sure major and minor tags are up to date on a patch release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run Update semver
+        uses: haya14busa/action-update-semver@v1


### PR DESCRIPTION
Make sure major and minor tags are up to date on a patch release.

This would allow the common practice to use major tag on the action:

```yaml
- name: Create bump and changelog
  uses: commitizen-tools/commitizen-action@0
```

(Ideally you may want to prefix version with `v` 🤷)

This what this third party action does under the hood:

```bash
$ TAG="0.21.0"
$ MINOR="${TAG%.*}"
$ echo $MINOR
0.21
$ MAJOR="${MINOR%.*}"
$ echo $MAJOR
0
```

This is used here for example: https://github.com/astral-sh/setup-uv/blob/main/.github/workflows/update-major-minor-tags.yml
