### PR TITLE
Fixes #91 Update entrypoint.sh make check_consistency need to be "true"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ fi
 if [[ $INPUT_INCREMENT ]]; then
   CZ_CMD+=('--increment' "$INPUT_INCREMENT")
 fi
-if [[ $INPUT_CHECK_CONSISTENCY ]]; then
+if [[ $INPUT_CHECK_CONSISTENCY == 'true' ]]; then
   CZ_CMD+=('--check-consistency')
 fi
 if [[ $INPUT_GIT_REDIRECT_STDERR == 'true' ]]; then


### PR DESCRIPTION
This ensures we can turn off check_consistency and the default behavior works,