### PR TITLE
feat(#55): add ACTOR input parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,27 +1,27 @@
-name: 'Bump and changelog using commitizen'
-description: 'Create a commit bumping the version of your project and creating a changelog file'
+name: "Bump and changelog using commitizen"
+description: "Create a commit bumping the version of your project and creating a changelog file"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 branding:
-  icon: 'git-commit'
-  color: 'purple'
+  icon: "git-commit"
+  color: "purple"
 outputs:
   version:
-    description: 'New version'
+    description: "New version"
 inputs:
   working_directory:
-    description: 'Change to this directory before running'
+    description: "Change to this directory before running"
     required: false
   dry_run:
-    description: 'Run without creating commit, output to stdout'
+    description: "Run without creating commit, output to stdout"
     required: false
   commit:
-    description: 'If true a commit is created containing the bump changes'
+    description: "If true a commit is created containing the bump changes"
     required: false
     default: "true"
   push:
-    description: 'If true the bump commit is pushed to the remote repository'
+    description: "If true the bump commit is pushed to the remote repository"
     required: false
     default: "true"
   merge:
@@ -31,62 +31,62 @@ inputs:
     required: false
     default: "false"
   prerelease:
-    description: 'Set as prerelease version'
+    description: "Set as prerelease version"
     required: false
   devrelease:
-    description: 'Non-negative integer for dev. release'
+    description: "Non-negative integer for dev. release"
     required: false
   local_version:
-    description: 'Bump only the local version portion'
+    description: "Bump only the local version portion"
     required: false
     default: "false"
   changelog:
-    description: 'Create changelog when bumping the version'
+    description: "Create changelog when bumping the version"
     default: "true"
     required: false
   github_token:
     description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
     required: false
   repository:
-    description: 'Repository name to push. Default or empty value represents current github repository (${GITHUB_REPOSITORY})'
-    default: ''
+    description: "Repository name to push. Default or empty value represents current github repository (${GITHUB_REPOSITORY})"
+    default: ""
     required: false
   branch:
-    description: 'Destination branch to push changes'
+    description: "Destination branch to push changes"
     required: false
-    default: ''
+    default: ""
   extra_requirements:
-    description: 'Extra commitizen dependencies like your custom plugins or rules'
+    description: "Extra commitizen dependencies like your custom plugins or rules"
     required: false
-    default: ''
+    default: ""
   changelog_increment_filename:
-    description: 'Filename to store the incremented generated changelog. This is different to changelog as it only contains the changes for the just generated version'
+    description: "Filename to store the incremented generated changelog. This is different to changelog as it only contains the changes for the just generated version"
     required: false
   git_redirect_stderr:
-    description: 'Redirect git output to stderr. Useful if you do not want git output in your changelog'
+    description: "Redirect git output to stderr. Useful if you do not want git output in your changelog"
     required: false
     default: "false"
   git_name:
-    description: 'Name used to configure git (for git operations)'
+    description: "Name used to configure git (for git operations)"
     required: false
-    default: 'github-actions[bot]'
+    default: "github-actions[bot]"
   git_email:
-    description: 'Email address used to configure git (for git operations)'
+    description: "Email address used to configure git (for git operations)"
     required: false
-    default: 'github-actions[bot]@users.noreply.github.com'
+    default: "github-actions[bot]@users.noreply.github.com"
   commitizen_version:
-    description: 'Specify the version to be used by commitizen'
+    description: "Specify the version to be used by commitizen"
     required: false
     default: latest
   no_raise:
     description: "Don't raise the given comma-delimited exit codes"
     required: false
-    default: '21'
+    default: "21"
   increment:
     description: "Manually specify the desired increment"
     required: false
   check_consistency:
-    default: 'false'
+    default: "false"
     description: "check consistency among versions defined in commitizen configuration and version_files"
     required: false
   gpg_sign:
@@ -100,3 +100,6 @@ inputs:
     description: "If true, prints debug output to GitHub Actions stdout."
     required: false
     default: "false"
+  actor:
+    description: "The account that will be used to perform git operations, defaults to the GITHUB_ACTOR"
+    required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,6 +87,11 @@ else
   echo "${CZ_CMD[@]}"
   "${CZ_CMD[@]}"
 fi
+if [[ $INPUT_ACTOR ]]; then
+  ACTOR=$INPUT_ACTOR
+else
+  ACTOR=$GITHUB_ACTOR
+fi
 
 REV="$(cz version --project)"
 if [[ $REV == "$PREV_REV" ]]; then
@@ -101,7 +106,7 @@ INPUT_BRANCH="${INPUT_BRANCH:-$CURRENT_BRANCH}"
 INPUT_REPOSITORY="${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}"
 
 echo "Repository: ${INPUT_REPOSITORY}"
-echo "Actor: ${GITHUB_ACTOR}"
+echo "Actor: ${ACTOR}"
 
 if [[ $INPUT_PUSH == 'true' ]]; then
   if [[ $INPUT_MERGE != 'true' && $GITHUB_EVENT_NAME == 'pull_request' ]]; then
@@ -109,7 +114,7 @@ if [[ $INPUT_PUSH == 'true' ]]; then
     echo "You probably want to run on push to your default branch instead." >&2
   else
     echo "Pushing to branch..."
-    REMOTE_REPO="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@${GITHUB_DOMAIN}/${INPUT_REPOSITORY}.git"
+    REMOTE_REPO="https://${ACTOR}:${INPUT_GITHUB_TOKEN}@${GITHUB_DOMAIN}/${INPUT_REPOSITORY}.git"
     git pull "$REMOTE_REPO" "$INPUT_BRANCH"
     git push "$REMOTE_REPO" "HEAD:${INPUT_BRANCH}" --tags
   fi


### PR DESCRIPTION
Closes #55

Adding an ACTOR input parameter so that $GITHUB_ACTOR can be overridden.
This is useful so for example one can have branch protection rules that
allow pushing a tag directly to `main` if user X, but not for developers
