### PR TITLE
docs: fix broken commitizen documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,5 +203,5 @@ create a new commitizen python package, or you can describe it on the `toml` con
 [cz]: https://commitizen-tools.github.io/commitizen/
 [cc]: https://www.conventionalcommits.org/
 [semver]: https://semver.org/
-[cz-conf]: https://commitizen-tools.github.io/commitizen/config/
-[cz-custom]: https://commitizen-tools.github.io/commitizen/customization/
+[cz-conf]: https://commitizen-tools.github.io/commitizen/config/configuration_file/
+[cz-custom]: https://commitizen-tools.github.io/commitizen/customization/config_file/


### PR DESCRIPTION
## Why

Two reference link definitions in `README.md` point to URL paths that
no longer exist on the commitizen documentation site:

- `https://commitizen-tools.github.io/commitizen/config/` -> 404
- `https://commitizen-tools.github.io/commitizen/customization/` -> 404

Both are linked from the README body (the `commitizen's configuration
page` link in the *Minimal configuration* section, and the *Read more
about customization* link near the end), so users currently land on
404 pages.

## What

Update the link definitions to the new locations on the docs site:

- `cz-conf` -> `https://commitizen-tools.github.io/commitizen/config/configuration_file/`
- `cz-custom` -> `https://commitizen-tools.github.io/commitizen/customization/config_file/`

## How

The pages were renamed when the commitizen docs were reorganised into
sub-pages per topic. The new URLs point to the equivalent content
(configuration file format, and the customisation guide).

## Verification

`Invoke-WebRequest -Method Head` against the new and old URLs:

| URL | Status |
| --- | --- |
| (old) `.../config/` | 404 |
| (old) `.../customization/` | 404 |
| (new) `.../config/configuration_file/` | 200 |
| (new) `.../customization/config_file/` | 200 |

The new URLs are also referenced from the live commitizen docs
home page (e.g. `[Customizable](.../customization/config_file/)`),
confirming they are the canonical replacements.

Closes #106