### PR TITLE
fix: keep git output out of the changelog increment file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,6 +95,12 @@ if [[ $INPUT_MANUAL_VERSION ]]; then
   CZ_CMD+=("$INPUT_MANUAL_VERSION")
 fi
 if [[ $INPUT_CHANGELOG_INCREMENT_FILENAME ]]; then
+  # Avoid polluting the changelog increment file with git's commit output
+  # (e.g. "[main abcdef] bump: ..." and the file-change summary).
+  # Force git output to stderr unless the user already enabled it.
+  if [[ $INPUT_GIT_REDIRECT_STDERR != 'true' ]]; then
+    CZ_CMD+=('--git-output-to-stderr')
+  fi
   CZ_CMD+=('--changelog-to-stdout')
   echo "${CZ_CMD[@]}" ">$INPUT_CHANGELOG_INCREMENT_FILENAME"
   "${CZ_CMD[@]}" >"$INPUT_CHANGELOG_INCREMENT_FILENAME"


### PR DESCRIPTION
## Why

When `changelog_increment_filename` is set, the action redirects the
bump command's stdout to that file:

`ash
"${CZ_CMD[@]}" >"$INPUT_CHANGELOG_INCREMENT_FILENAME"
`

By default `cz bump` prints its post-bump `git commit` output to
stdout as well, so the file ends up containing not just the changelog
section but also the git noise:

```
## 0.21.0 (2024-05-15)

### Feat

- ...

[master abcdef] bump: version 0.20.0 -> 0.21.0
 2 files changed, 8 insertions(+), 1 deletion(-)
```

The user has to clean those last lines out before they can be used as
e.g. a release body, as reported in #82.

## What

When `changelog_increment_filename` is supplied, automatically pass
`--git-output-to-stderr` to `cz bump` (unless the user already set
`git_redirect_stderr: true`). The git commit summary then goes to
stderr (so it still shows in the action log) and the changelog file
contains only the changelog section.

## How

The fix is local to the `INPUT_CHANGELOG_INCREMENT_FILENAME` branch
in `entrypoint.sh`; behaviour is unchanged when
`changelog_increment_filename` is not used. Users who want the git
output in their changelog file can still get it by leaving
`git_redirect_stderr` at its default of `false` *and* not setting
`changelog_increment_filename`... which is the original use of the
flag.

## Verification

Repro on a fresh test repo with one `feat:` commit, simulating the
relevant section of `entrypoint.sh`:

**Before** (current `master`) -- `increment.md` contents:

```
## 0.1.0 (2026-05-10)

### Feat

- initial

[main f21d45e] bump: version 0.0.0 -> 0.1.0
 2 files changed, 6 insertions(+), 1 deletion(-)
 create mode 100644 CHANGELOG.md
```

**After** this fix -- `increment.md` contents:

```
## 0.1.0 (2026-05-10)

### Feat

- initial
```

The git output (`[main f21d45e] ...` and the file-change summary)
appears on stderr instead, so it still shows up in the workflow log
but no longer pollutes the file.

Closes #82