### PR TITLE
fix: report new version when commit is false and no version files update

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,6 +94,24 @@ fi
 if [[ $INPUT_MANUAL_VERSION ]]; then
   CZ_CMD+=("$INPUT_MANUAL_VERSION")
 fi
+
+# Capture the would-be next version BEFORE running the actual bump.
+# This is used as a fallback for the version output when `cz version --project`
+# does not reflect the bump (e.g. version_provider=scm combined with
+# commit:false, where neither version files nor git tags are updated).
+# Strip `--changelog` and `--changelog-to-stdout` for the `--get-next` call:
+# in commitizen < 4.10.1 these flags are incompatible with `--get-next`
+# (NotAllowed); in newer versions they emit a no-op warning. Either way
+# `--get-next` does not generate a changelog so the flag is unnecessary.
+GET_NEXT_CMD=()
+for arg in "${CZ_CMD[@]}"; do
+  if [[ $arg != '--changelog' && $arg != '--changelog-to-stdout' ]]; then
+    GET_NEXT_CMD+=("$arg")
+  fi
+done
+# Failures (no bumpable commits, etc.) are tolerated and produce an empty value.
+NEXT_REV_PRE="$("${GET_NEXT_CMD[@]}" --get-next 2>/dev/null || true)"
+
 if [[ $INPUT_CHANGELOG_INCREMENT_FILENAME ]]; then
   CZ_CMD+=('--changelog-to-stdout')
   echo "${CZ_CMD[@]}" ">$INPUT_CHANGELOG_INCREMENT_FILENAME"
@@ -109,6 +127,20 @@ else
 fi
 
 REV="$(cz version --project)"
+NEXT_REV_MAJOR="$(cz version --project --major)"
+NEXT_REV_MINOR="$(cz version --project --minor)"
+
+# Fall back to the pre-computed --get-next value when `cz version --project`
+# did not reflect the bump. This happens with version_provider=scm and
+# commit:false, where the bump does not update any tracked files and no
+# tag is created, so the project's reported version remains unchanged.
+if [[ $REV == "$PREV_REV" && -n "$NEXT_REV_PRE" && "$NEXT_REV_PRE" != "$PREV_REV" ]]; then
+  REV="$NEXT_REV_PRE"
+  NEXT_REV_MAJOR="${REV%%.*}"
+  NEXT_REV_REST="${REV#*.}"
+  NEXT_REV_MINOR="${NEXT_REV_REST%%.*}"
+fi
+
 if [[ $REV == "$PREV_REV" ]]; then
   INPUT_PUSH='false'
 fi
@@ -116,10 +148,8 @@ echo "REVISION=${REV}" >>"$GITHUB_ENV"
 echo "version=${REV}" >>"$GITHUB_OUTPUT"
 echo "next_version=${REV}" >>"$GITHUB_OUTPUT"
 
-NEXT_REV_MAJOR="$(cz version --project --major)"
 echo "NEXT_REVISION_MAJOR=${NEXT_REV_MAJOR}" >>"$GITHUB_ENV"
 echo "next_version_major=${NEXT_REV_MAJOR}" >>"$GITHUB_OUTPUT"
-NEXT_REV_MINOR="$(cz version --project --minor)"
 echo "NEXT_REVISION_MINOR=${NEXT_REV_MINOR}" >>"$GITHUB_ENV"
 echo "next_version_minor=${NEXT_REV_MINOR}" >>"$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Why

`outputs.version` (and `next_version`, `next_version_major`,
`next_version_minor`) are sourced from `cz version --project`
*after* the bump runs. That works fine when the bump updates a
tracked version file or creates a tag.

When `commit: false` is combined with a `version_provider` that
does not write to any tracked file -- notably
`version_provider = ""scm""` -- the bump:

- does not update any version file (scm reads version from git tags),
- does not create a git tag (since `commit: false` implies no
  bump commit, and without a commit there is nothing to tag).

So `cz version --project` keeps reporting the *previous* version,
even though `cz bump` itself printed `bump: version X -> Y`
correctly. The action then exposes the old version on every
`version`-shaped output, defeating the documented use case in #94
of running the action purely to compute the next version (no commit,
no push) for downstream steps.

## What

Capture the would-be next version with `cz bump --get-next` *before*
running the actual bump. `--get-next` is a pure computation -- it
does not change any state -- so it is safe to run as a second pass.
Reuse the same `CZ_CMD` array (minus `--changelog` /
`--changelog-to-stdout`) so the captured value honours
`--increment`, `--prerelease`, `--build-metadata`, etc.

After the bump, if `cz version --project` still equals the previous
version *and* `--get-next` produced a different version, fall back
to the captured value for `version`, `next_version`,
`next_version_major` and `next_version_minor`. Major and minor are
parsed from the captured version string so they match.

If `--get-next` itself fails (e.g. no commits eligible to bump,
exit 21) the captured value stays empty and the fallback is skipped,
preserving today's behaviour for that case.

## How

Surgical change to `entrypoint.sh` only, no input/output schema
changes:

1. After `CZ_CMD` is fully built and before the actual bump runs,
   build a filtered `GET_NEXT_CMD` that drops `--changelog` and
   `--changelog-to-stdout` (see *Compatibility note* below), then
   compute `NEXT_REV_PRE="$("${GET_NEXT_CMD[@]}" --get-next 2>/dev/null || true)"`.
2. After the bump, populate `REV`, `NEXT_REV_MAJOR` and
   `NEXT_REV_MINOR` from `cz version --project` as before, then
   override them with the captured value when `REV == PREV_REV`
   and a non-empty different `NEXT_REV_PRE` is available.

### Compatibility note: `--get-next` + `--changelog`

In commitizen < 4.10.1, `--get-next` combined with `--changelog`
or `--changelog-to-stdout` raises `NotAllowed`
(commitizen-tools/commitizen#1640). Since the action defaults to
`commitizen_version: latest` but allows pinning to older releases,
the simplest forward- and backward-compatible solution is to strip
those two flags before calling `--get-next`. `--get-next` does
not produce a changelog regardless, so the flags have no effect on
the captured value. In commitizen >= 4.10.1 (commitizen-tools/commitizen#1645)
they are tolerated as no-op warnings; the strip keeps the action's
log output clean as a side benefit.

## Verification

Repro on a fresh test repo with one `feat:` commit and the user's
config (`version_provider = ""scm""`), simulating the relevant
section of `entrypoint.sh` with `commit: false`:

**Before** (current `master`):

```
PREV_REV=0.0.0
bump: version 0.0.0 -> 0.1.0
tag to create: 0.1.0
increment detected: MINOR
Post-bump: REV='0.0.0' MAJOR='0' MINOR='0'
=== Final outputs ===
version=0.0.0
next_version_major=0
next_version_minor=0
```

**After** this fix:

```
PREV_REV=0.0.0
CZ_CMD: cz --no-raise 21 bump --yes --changelog --files-only
GET_NEXT_CMD: cz --no-raise 21 bump --yes --files-only
NEXT_REV_PRE='0.1.0'
bump: version 0.0.0 -> 0.1.0
tag to create: 0.1.0
increment detected: MINOR
Post-bump: REV='0.0.0' MAJOR='0' MINOR='0'
Fallback applied!
=== Final outputs ===
version=0.1.0
next_version_major=0
next_version_minor=1
```

I also re-checked the other cases:

- `commit: true` (default) with file-based version_provider -- bump
  updates `.cz.toml` and creates a commit, so `cz version --project`
  already reflects the new version, the fallback condition
  `REV == PREV_REV` is false, and behaviour is unchanged.
- `commit: false` with file-based version_provider -- `--files-only`
  updates `.cz.toml`, `cz version --project` returns the new
  version, fallback also skipped.
- No bumpable commits -- `--get-next` exits with empty stdout,
  fallback skipped, `INPUT_PUSH` is still set to `false` as today.

Closes #94